### PR TITLE
pass noHostTags query param to chart api keys call

### DIFF
--- a/dist/plugin/datasource.js
+++ b/dist/plugin/datasource.js
@@ -310,7 +310,7 @@ System.register(["lodash", "./functions", "./helpers", "./backendSrvCanelledRetr
                         query: query, name: "queryKeyLookup",
                     }], start: lookbackStartSecs,
             };
-            var reqConfig = _this.baseRequestConfig("GET", "chart/api/keys", {
+            var reqConfig = _this.baseRequestConfig("GET", "chart/api/keys?noHostTags=true", {
                 request: request,
             });
             return _this.backendSrv.datasourceRequest(reqConfig);

--- a/src/plugin/datasource.ts
+++ b/src/plugin/datasource.ts
@@ -384,7 +384,7 @@ export function WavefrontDatasource(instanceSettings, $q, backendSrv, templateSr
             }], start: lookbackStartSecs,
         };
 
-        const reqConfig = this.baseRequestConfig("GET", "chart/api/keys", {
+        const reqConfig = this.baseRequestConfig("GET", "chart/api/keys?noHostTags=true", {
             request,
         });
 


### PR DESCRIPTION
tested and works in our grafana setup. 

Request URL looks like 
>https://lyft.wavefront.com/chart/api/keys?noHostTags=true&request=%7B%22queries%22:%5B%7B%22query%22:%22ts(%5C%22production.infra.aws.autoscaling.grouptotalinstances.average%5C%22,autoscalinggroupname%3D%5C%22*%5C%22)%22,%22name%22:%22queryKeyLookup%22%7D%5D,%22start%22:1508951079%7D
