### PR TITLE
Update datasource.ts

### DIFF
--- a/src/plugin/datasource.ts
+++ b/src/plugin/datasource.ts
@@ -404,10 +404,11 @@ export function WavefrontDatasource(instanceSettings, $q, backendSrv, templateSr
            noHostTags: true,
         };
 
-        const hostTagsFilter = includeHostTags ? "" : "?noHostTags=true";
+        const hostTagsFilter = includeHostTags ? "false" : "true";
 
-        const reqConfig = this.baseRequestConfig("GET", "chart/api/keys" + hostTagsFilter, {
+        const reqConfig = this.baseRequestConfig("GET", "chart/api/keys", {
             request: JSON.stringify(request),
+            noHostTags: hostTagsFilter
         });
 
         return this.backendSrv.datasourceRequest(reqConfig);


### PR DESCRIPTION
the code had a bug where generated URL will contain two '?' characters in the parameter part of URL - causing the wavefront API to return 403 error.